### PR TITLE
Check ErrorCode for templated email (similar as it is done in SendEmail)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kiddom/postmark
+module github.com/radim/postmark
 
 go 1.13
 

--- a/templates.go
+++ b/templates.go
@@ -212,6 +212,11 @@ func (client *Client) SendTemplatedEmail(email TemplatedEmail) (EmailResponse, e
 		Payload:   email,
 		TokenType: server_token,
 	}, &res)
+
+	if res.ErrorCode != 0 {
+		return res, fmt.Errorf(`%v %s`, res.ErrorCode, res.Message)
+	}
+
 	return res, err
 }
 
@@ -227,5 +232,10 @@ func (client *Client) SendTemplatedEmailBatch(emails []TemplatedEmail) ([]EmailR
 		Payload:   formatEmails,
 		TokenType: server_token,
 	}, &res)
+
+	if res.ErrorCode != 0 {
+		return res, fmt.Errorf(`%v %s`, res.ErrorCode, res.Message)
+	}
+
 	return res, err
 }


### PR DESCRIPTION
`SendTemplatedEmail` and `SendTemplatedEmailBatch` are not handling API errors the same way as `SendEmail`. Added ErrorCode check.