### PR TITLE
Check ErrorCode for templated email (similar as it is done in SendEmail)

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -212,6 +212,11 @@ func (client *Client) SendTemplatedEmail(email TemplatedEmail) (EmailResponse, e
 		Payload:   email,
 		TokenType: server_token,
 	}, &res)
+
+	if res.ErrorCode != 0 {
+		return res, fmt.Errorf(`%v %s`, res.ErrorCode, res.Message)
+	}
+
 	return res, err
 }
 


### PR DESCRIPTION
SendTemplatedEmail is not handling API errors the same way as SendEmail. Added ErrorCode check.