### PR TITLE
add link option in template

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -197,6 +197,9 @@ type TemplatedEmail struct {
 	ReplyTo string `json:",omitempty"`
 	// Headers: List of custom headers to include.
 	Headers []Header `json:",omitempty"`
+	// TrackLinks: Activate link tracking for links in the HTML or Text bodies of this email.
+	// Possible options: None HtmlAndText HtmlOnly TextOnly
+	TrackLinks TrackLinksOption `json:",omitempty"`
 	// TrackOpens: Activate open tracking for this email.
 	TrackOpens bool `json:",omitempty"`
 	// Attachments: List of attachments

--- a/templates_test.go
+++ b/templates_test.go
@@ -231,6 +231,7 @@ var testTemplatedEmail = TemplatedEmail{
 		},
 	},
 	TrackOpens: true,
+	TrackLinks: HTMLAndTextTrackLinks,
 	Attachments: []Attachment{
 		{
 			Name:        "readme.txt",


### PR DESCRIPTION
The magic link can only work for Andriod with this link option 

Asana:
====
https://app.asana.com/0/776368917881667/1133567993375603